### PR TITLE
add etcd.service mask

### DIFF
--- a/user-data.sample
+++ b/user-data.sample
@@ -16,6 +16,8 @@ coreos:
   flannel:
     interface: $public_ipv4
   units:
+    - name: etcd.service
+      mask: true
     - name: etcd2.service
       command: start
     - name: fleet.service


### PR DESCRIPTION
If accidentally one of your units files use etcd.service instead of etcd2.service in its requirements, the cluster will start not to behave normally. 

fleetctl will give the following error: 
error 503 fleet server unable to communicate with etcd

In case it happens already the fix:
Find the node which fleet scheduler loaded, and then: 

```

sudo systemctl status etcd.service # if running
sudo systemctl stop etcd.service # check status again be sure it stopped
sudo systemctl mask etcd.service # then mask it, so it wont start again.
sudo systemctl start etcd2.service 
```

In order not to have the problem over and over again adding etcd.service mask.

https://github.com/deis/deis/issues/3564#issuecomment-118225429
